### PR TITLE
Fix Upload by Blob Client 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
 
-    implementation("com.amazonaws:aws-java-sdk-s3:1.12.130")
-    implementation("com.azure:azure-storage-blob:12.14.2")
+    implementation("com.amazonaws:aws-java-sdk-s3:1.12.523")
+    implementation("com.azure:azure-storage-blob:12.23.0")
 
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/src/main/kotlin/io/mustelidae/seaotter/api/controller/SimpleUploadController.kt
+++ b/src/main/kotlin/io/mustelidae/seaotter/api/controller/SimpleUploadController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+import java.net.URL
 
 @Api(tags = ["Simple Image Upload"])
 @RestController

--- a/src/main/kotlin/io/mustelidae/seaotter/constant/ImageFileFormat.kt
+++ b/src/main/kotlin/io/mustelidae/seaotter/constant/ImageFileFormat.kt
@@ -1,14 +1,46 @@
 package io.mustelidae.seaotter.constant
 
-enum class ImageFileFormat(val support: Boolean) {
-    JPG(true), JPEG(true), JFIF(false), // JPEG (Joint Photographic Experts Group) is a lossy compression method; JPEG-compressed images are usually stored in the JFIF (JPEG File Interchange Format) file format.
-    JP2(false), // JPEG 2000 is a compression standard enabling both lossless and lossy storage
-    TIFF(true), // The TIFF (Tagged Image File Format) format is a flexible format that normally saves eight bits or sixteen bits per color (red, green, blue) for 24-bit and 48-bit totals, respectively, usually using either the TIFF or TIF filename extension
-    GIF(false), // GIF (Graphics Interchange Format) is in normal use limited to an 8-bit palette, or 256 colors (while 24-bit color depth is technically possible).
-    BMP(true), // The BMP file format (Windows bitmap) handles graphic files within the Microsoft Windows OS
-    PNG(true), // The PNG (Portable Network Graphics) file format was created as a free, open-source alternative to GIF
-    PPM(false), PGM(false), PBM(false), PNM(false), // Netpbm format is a family including the portable pixmap file format (PPM), the portable graymap file format (PGM) and the portable bitmap file format (PBM)
-    WEBP(false), // WebP is a new open image format that uses both lossless and lossy compression.
-    HDR(true), // Most typical raster formats cannot store HDR data (32 bit floating point values per pixel component), which is why some relatively old or complex formats are still predominant here, and worth mentioning separately.
-    HEIF(false) // The High Efficiency Image File Format (HEIF) is an image container format that was standardized by MPEG on the basis of the ISO base media file format.
+
+enum class ImageFileFormat(
+    val support: Boolean,
+    /**
+     * Common MIME type
+     * @ref https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+     */
+    val mediaType: String
+) {
+    // JPEG (Joint Photographic Experts Group) is a lossy compression method; JPEG-compressed images are usually stored in the JFIF (JPEG File Interchange Format) file format.
+    JPG(true, "image/jpeg"),
+    JPEG(true, "image/jpeg"),
+    JFIF(false, "image/jpeg"),
+
+    // JPEG 2000 is a compression standard enabling both lossless and lossy storage
+    JP2(false, "image/jpeg"),
+
+    // The TIFF (Tagged Image File Format) format is a flexible format that normally saves eight bits or sixteen bits per color (red, green, blue) for 24-bit and 48-bit totals, respectively, usually using either the TIFF or TIF filename extension
+    TIFF(true, "image/tiff"),
+
+    // GIF (Graphics Interchange Format) is in normal use limited to an 8-bit palette, or 256 colors (while 24-bit color depth is technically possible).
+    GIF(false, "image/gif"),
+
+    // The BMP file format (Windows bitmap) handles graphic files within the Microsoft Windows OS
+    BMP(true, "image/bmp"),
+
+    // The PNG (Portable Network Graphics) file format was created as a free, open-source alternative to GIF
+    PNG(true, "image/png"),
+
+    // Netpbm format is a family including the portable pixmap file format (PPM), the portable graymap file format (PGM) and the portable bitmap file format (PBM)
+    PPM(false, "image/ppm"),
+    PGM(false, "image/pgm"),
+    PBM(false, "image/pbm"),
+    PNM(false, "image/pnm"),
+
+    // WebP is a new open image format that uses both lossless and lossy compression.
+    WEBP(false, "image/webp"),
+
+    // Most typical raster formats cannot store HDR data (32 bit floating point values per pixel component), which is why some relatively old or complex formats are still predominant here, and worth mentioning separately.
+    HDR(true, "image/hdr"),
+
+    // The High Efficiency Image File Format (HEIF) is an image container format that was standardized by MPEG on the basis of the ISO base media file format.
+    HEIF(false,"image/heif")
 }

--- a/src/main/kotlin/io/mustelidae/seaotter/domain/delivery/Image.kt
+++ b/src/main/kotlin/io/mustelidae/seaotter/domain/delivery/Image.kt
@@ -12,6 +12,7 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.URL
+import java.util.Locale
 import javax.imageio.ImageIO
 
 data class Image(
@@ -57,7 +58,7 @@ data class Image(
             return Image(
                 ImageIO.read(file),
                 file.nameWithoutExtension,
-                ImageFileFormat.valueOf(file.extension.toUpperCase()),
+                ImageFileFormat.valueOf(file.extension.uppercase(Locale.getDefault())),
                 true
             )
         }
@@ -70,7 +71,7 @@ data class Image(
 
             try {
                 val extension = base64Regex.find(base64.substring(0, index))!!.groupValues[2]
-                format = ImageFileFormat.valueOf(extension.toUpperCase())
+                format = ImageFileFormat.valueOf(extension.uppercase(Locale.getDefault()))
             } catch (e: NullPointerException) {
                 throw java.lang.IllegalArgumentException("invalid base 64 image format")
             } catch (e: java.lang.IllegalArgumentException) {
@@ -102,7 +103,7 @@ data class Image(
     }
 
     fun getExtension(): String {
-        return imageFileFormat.name.toLowerCase()
+        return imageFileFormat.name.lowercase(Locale.getDefault())
     }
 
     fun getMeta(): Meta {

--- a/src/main/kotlin/io/mustelidae/seaotter/domain/delivery/Image.kt
+++ b/src/main/kotlin/io/mustelidae/seaotter/domain/delivery/Image.kt
@@ -11,6 +11,7 @@ import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.net.URL
 import javax.imageio.ImageIO
 
 data class Image(

--- a/src/main/kotlin/io/mustelidae/seaotter/domain/uploader/AzureStorageUploader.kt
+++ b/src/main/kotlin/io/mustelidae/seaotter/domain/uploader/AzureStorageUploader.kt
@@ -6,7 +6,6 @@ import com.azure.storage.blob.models.BlobHttpHeaders
 import com.azure.storage.common.StorageSharedKeyCredential
 import io.mustelidae.seaotter.config.AppEnvironment
 import io.mustelidae.seaotter.domain.delivery.Image
-import org.springframework.http.MediaType
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 

--- a/src/main/kotlin/io/mustelidae/seaotter/domain/uploader/AzureStorageUploader.kt
+++ b/src/main/kotlin/io/mustelidae/seaotter/domain/uploader/AzureStorageUploader.kt
@@ -2,9 +2,11 @@ package io.mustelidae.seaotter.domain.uploader
 
 import com.azure.core.util.BinaryData
 import com.azure.storage.blob.BlobServiceClientBuilder
+import com.azure.storage.blob.models.BlobHttpHeaders
 import com.azure.storage.common.StorageSharedKeyCredential
 import io.mustelidae.seaotter.config.AppEnvironment
 import io.mustelidae.seaotter.domain.delivery.Image
+import org.springframework.http.MediaType
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 
@@ -19,26 +21,26 @@ internal class AzureStorageUploader(
 ) : Uploader {
 
     override fun upload(image: Image): String {
-        val directoryPath = DirectoryPath(azureStorage.path, azureStorage.shardType, topicCode).apply {
-            append(image.isOriginal)
-        }
-
+        val directoryPath = DirectoryPath(azureStorage.path, azureStorage.shardType, topicCode)
         val credential = StorageSharedKeyCredential(azureStorage.accountName, azureStorage.accountKey)
 
         val blobClient = BlobServiceClientBuilder()
             .endpoint(azureStorage.endpoint)
             .credential(credential)
             .buildClient()
-            .getBlobContainerClient(directoryPath.getPath()).apply {
-                create()
-            }.getBlobClient(image.name)
+            .getBlobContainerClient(directoryPath.getPath())
+            .getBlobClient(image.name)
 
         val out = ByteArrayOutputStream()
         ImageIO.write(image.bufferedImage, image.getExtension(), out)
         val byteArray = out.toByteArray()
 
-        blobClient.upload(BinaryData.fromBytes(byteArray))
+        val headers = BlobHttpHeaders().apply {
+            contentType = image.imageFileFormat.mediaType
+        }
+        blobClient.setHttpHeaders(headers)
 
+        blobClient.upload(BinaryData.fromBytes(byteArray))
         return blobClient.blobUrl
     }
 }


### PR DESCRIPTION
Currently, the Header setting of Blob Storage is empty.
Because of this, Azure blobs are stored as application/octet-stream.
This part was converted to Media Type.